### PR TITLE
multi-module-tutorial : 간단한 EchoBoard 조회 API 추가

### DIFF
--- a/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/entity/EchoBoardEntity.kt
+++ b/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/entity/EchoBoardEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import me.practice.tutorialdomain.domain.EchoBoard
 import java.time.LocalDateTime
 
 @Table(name = "echo_board")
@@ -17,4 +18,18 @@ class EchoBoardEntity(
     var id: Long = 0L
     var createdDt: LocalDateTime = LocalDateTime.now()
     var updatedDt: LocalDateTime? = null
+
+    fun toModel() = EchoBoard(
+        id = id,
+        name = name,
+        createdDt = createdDt
+    )
+
+    companion object {
+        fun from(model: EchoBoard) = with(model) {
+            EchoBoardEntity(
+                name = model.name
+            )
+        }
+    }
 }

--- a/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardJpaRepository.kt
+++ b/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardJpaRepository.kt
@@ -4,4 +4,5 @@ import me.practice.tutorialpostgresql.entity.EchoBoardEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface EchoBoardJpaRepository : JpaRepository<EchoBoardEntity, Long> {
+    fun existsByName(name: String): Boolean
 }

--- a/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardRepositoryImpl.kt
+++ b/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package me.practice.tutorialpostgresql.repository
+
+import me.practice.tutorialdomain.domain.EchoBoard
+import me.practice.tutorialdomain.repository.IEchoBoardRepository
+import me.practice.tutorialpostgresql.entity.EchoBoardEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class EchoBoardRepositoryImpl(
+    private val echoBoardJpaRepository: EchoBoardJpaRepository
+) : IEchoBoardRepository {
+    override fun save(echoBoard: EchoBoard): EchoBoard {
+        return echoBoardJpaRepository.save(EchoBoardEntity.from(echoBoard)).toModel()
+    }
+
+    override fun saveAll(echoBoards: List<EchoBoard>): List<EchoBoard> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findById(id: Long): EchoBoard {
+        return echoBoardJpaRepository.findById(id)
+            .orElseThrow()
+            .toModel()
+    }
+
+    override fun existsByName(name: String): Boolean {
+        return echoBoardJpaRepository.existsByName(name)
+    }
+}

--- a/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardRepositoryImpl.kt
+++ b/multi-module-tutorial/infra/db/tutorial-postgresql/src/main/kotlin/me/practice/tutorialpostgresql/repository/EchoBoardRepositoryImpl.kt
@@ -3,8 +3,12 @@ package me.practice.tutorialpostgresql.repository
 import me.practice.tutorialdomain.domain.EchoBoard
 import me.practice.tutorialdomain.repository.IEchoBoardRepository
 import me.practice.tutorialpostgresql.entity.EchoBoardEntity
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.stereotype.Repository
 
+// 최초에 패키지 구성을 바보같이 해놔서, 실행모듈 입장에서 패키지 구조를 통해 자동으로 스캔이 불가능.
+// 따라서 직접 스캔할 패키지명을 임시로 명시하여 실행되도록 함
+@EnableJpaRepositories("me.practice.tutorialpostgresql.repository")
 @Repository
 class EchoBoardRepositoryImpl(
     private val echoBoardJpaRepository: EchoBoardJpaRepository

--- a/multi-module-tutorial/tutorial-domain/build.gradle.kts
+++ b/multi-module-tutorial/tutorial-domain/build.gradle.kts
@@ -1,11 +1,27 @@
 description = "tutorial-domain module"
 
 plugins {
-    id("java-library")  // 다른 모듈에서 참조할 수 있도록 라이브러리 모듈로 설정
+    id("java-library")  // 현재 domain 모듈을 다른 모듈에서 참조할 수 있도록 라이브러리 모듈로 설정
+
+    /**
+     * 아래 plugin 없이 @Service annotation 을 쓰려고 하면, 당연하게도 import 가 안된다.
+     * - @Service 는 spring-context dependency 에 존재. 하지만 아래 플러그인으로 관련 의존성을 가져오지 못하면 의미 없음.
+     * 아래 plugin 의 역할에 대해서는 root build.gradle.kts 를 확인해라.
+     */
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+
+    // @Component 등의 어노테이션이 붙은 클래스에 open keyword 를 자동으로 붙여주기 위해 선언
+    // Kotlin 은 기본적으로 불변 객체라 final class 임.
+    // 따라서 AOP, Proxy 등을 사용하기 위해서는 반드시 필요한 플러그인.
+    // https://engineerinsight.tistory.com/54
+    kotlin("plugin.spring")
 }
 
 dependencies {
     implementation(kotlin("stdlib")) // 순수 Kotlin 라이브러리 사용
+    implementation("org.springframework:spring-context") // @Service ...
+    implementation("org.springframework:spring-tx") // @Transactional
 
     // 테스트용
     testImplementation(kotlin("test"))
@@ -15,8 +31,6 @@ java {
     withSourcesJar() // 소스 코드 JAR 생성 (다른 모듈에서 사용 가능하도록)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "17" // JDK 17 사용
-    }
+tasks.getByName("bootJar") {
+    enabled = false
 }

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoBoard.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoBoard.kt
@@ -1,4 +1,4 @@
-package me.practice.tutorialdomain
+package me.practice.tutorialdomain.domain
 
 import java.time.LocalDateTime
 

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoBoard.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoBoard.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
  * 유저가 게시글을 작성할 게시판
  */
 data class EchoBoard(
-    var id: Long,
+    var id: Long? = null,
     var name: String,
-    var createdDt: LocalDateTime,
+    var createdDt: LocalDateTime = LocalDateTime.now(),
 )

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoPosting.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoPosting.kt
@@ -1,4 +1,4 @@
-package me.practice.tutorialdomain
+package me.practice.tutorialdomain.domain
 
 import java.time.LocalDateTime
 

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoUser.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/domain/EchoUser.kt
@@ -1,4 +1,4 @@
-package me.practice.tutorialdomain
+package me.practice.tutorialdomain.domain
 
 import java.time.LocalDateTime
 

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/repository/IEchoBoardRepository.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/repository/IEchoBoardRepository.kt
@@ -1,0 +1,10 @@
+package me.practice.tutorialdomain.repository
+
+import me.practice.tutorialdomain.domain.EchoBoard
+
+interface IEchoBoardRepository {
+    fun save(echoBoard: EchoBoard): EchoBoard
+    fun saveAll(echoBoards: List<EchoBoard>): List<EchoBoard>
+    fun findById(id: Long): EchoBoard
+    fun existsByName(name: String): Boolean
+}

--- a/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/service/EchoBoardService.kt
+++ b/multi-module-tutorial/tutorial-domain/src/main/kotlin/me/practice/tutorialdomain/service/EchoBoardService.kt
@@ -1,0 +1,32 @@
+package me.practice.tutorialdomain.service
+
+import me.practice.tutorialdomain.domain.EchoBoard
+import me.practice.tutorialdomain.repository.IEchoBoardRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional // sprint-tx
+@Service // spring-context 의존성으로 사용 가능
+class EchoBoardService(
+    private val echoBoardRepository: IEchoBoardRepository
+) {
+    @Transactional(readOnly = true)
+    fun createBoard(name: String): Boolean {
+        if (echoBoardRepository.existsByName(name)) {
+            throw IllegalArgumentException("duplicated echo board name: $name")
+        }
+
+        val board = EchoBoard(id = null, name = name)
+        echoBoardRepository.save(board)
+
+        return true
+    }
+
+    fun findBoard(id: Long): EchoBoard {
+        if (id <= 0L) {
+            throw IllegalArgumentException("invalid echo board id value: $id")
+        }
+
+        return echoBoardRepository.findById(id)
+    }
+}

--- a/multi-module-tutorial/tutorial-web/build.gradle.kts
+++ b/multi-module-tutorial/tutorial-web/build.gradle.kts
@@ -6,21 +6,22 @@
  * 덕분에 플러그인을 명시만 하면 되고, 버전은 root 에서 간편하게 관리할 수 있음.
  */
 plugins {
-	kotlin("plugin.spring")
 	id("org.springframework.boot")
 	id("io.spring.dependency-management")
+
+	// @Component annotation 을 사용할 때, open class 로 자동으로 만들기 위한 플러그인
+	kotlin("plugin.spring")
 }
 
-// 실행 확인을 위한 옵션
-//tasks.getByName("bootJar") {
-//	enabled = true
-//}
-//
-//tasks.getByName("jar") {
-//	enabled = false
-//}
-
 dependencies {
+	implementation(project(":tutorial-domain"))
+	runtimeOnly(project(":infra:db:tutorial-postgresql"))
+
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks {
+	bootJar { enabled = true }
+	jar { enabled = false }
 }

--- a/multi-module-tutorial/tutorial-web/src/main/kotlin/me/practice/tutorialweb/TutorialWebApplication.kt
+++ b/multi-module-tutorial/tutorial-web/src/main/kotlin/me/practice/tutorialweb/TutorialWebApplication.kt
@@ -1,8 +1,14 @@
 package me.practice.tutorialweb
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.ComponentScan
 
+// 최초에 패키지 구성을 바보같이 해놔서, 실행모듈 입장에서 패키지 구조를 통해 자동으로 스캔이 불가능.
+// 따라서 직접 스캔할 패키지명을 임시로 명시하여 실행되도록 함
+@ComponentScan("me.practice") // 가장 상위 패키지부터 전부 포함
+@EntityScan("me.practice") // entity 스캔
 @SpringBootApplication
 class TutorialWebApplication
 

--- a/multi-module-tutorial/tutorial-web/src/main/kotlin/me/practice/tutorialweb/controller/EchoBoardController.kt
+++ b/multi-module-tutorial/tutorial-web/src/main/kotlin/me/practice/tutorialweb/controller/EchoBoardController.kt
@@ -1,0 +1,20 @@
+package me.practice.tutorialweb.controller
+
+import me.practice.tutorialdomain.service.EchoBoardService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/echo-boards")
+@RestController
+class EchoBoardController(
+    private val echoBoardService: EchoBoardService
+) {
+    @GetMapping("/{id}")
+    fun detailEchoBoard(@PathVariable id: Long): ResponseEntity<String> {
+        val data = echoBoardService.findBoard(id)
+        return ResponseEntity.ok("id=${data.id}, name=${data.name}, created_dt=${data.createdDt}")
+    }
+}

--- a/multi-module-tutorial/tutorial-web/src/main/resources/application.properties
+++ b/multi-module-tutorial/tutorial-web/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=tutorial-web

--- a/multi-module-tutorial/tutorial-web/src/main/resources/application.yml
+++ b/multi-module-tutorial/tutorial-web/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tutorial
+    username: root
+    password: matsosik_password # local 환경에 있던 postgresql 계정...
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    show-sql: true
+    database: postgresql
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
- domain은 infra를 알 필요가 없음.
  - 그래서 인터페이스만 열어주는 것. ex) `IRepository` 패턴
- infra는 domain을 알아야 함. --> 실제 구현체
- 패키지 구조를 생각 안하고 만들어서 리팩터링 필요. 앞으로는 고려를 잘 해야할 듯.